### PR TITLE
Add configuration option to use fully qualified name in custom service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.venv
+.vscode
+.pytest_cache
+__pycache__

--- a/README.md
+++ b/README.md
@@ -55,4 +55,5 @@ For Django, add `"autodynatrace.wrappers.django"` to `INSTALLED_APPS`
 * `AUTODYNATRACE_APPLICATION_ID`: Overwrite the default Application Name for Flask and Django
 * `AUTODYNATRACE_CONTEXT_ROOT`: Overwrite the default Context Root for Flask and Django
 * `AUTODYNATRACE_CUSTOM_SERVICE_NAME`: Overwrite the custom service name (used by `@autodynatrace.trace`)
+* `AUTODYNATRACE_CUSTOM_SERVICE_USE_FQN`: Default `False`, set to `True` to use fully qualified names for service and method names in custom traced services
 * `AUTODYNATRACE_INSTRUMENT_<LIB_NAME>`: If set to `False`, Disables the instrumentation for a specific lib, example: `AUTODYNATRACE_INSTRUMENT_CONCURRENT=False`, default is `True`

--- a/autodynatrace/wrappers/custom/wrapper.py
+++ b/autodynatrace/wrappers/custom/wrapper.py
@@ -5,23 +5,55 @@ from ...log import logger
 from ...sdk import sdk
 
 
+def use_fully_qualified_name():
+    return os.environ.get("AUTODYNATRACE_CUSTOM_SERVICE_USE_FQN") \
+           and os.environ.get("AUTODYNATRACE_CUSTOM_SERVICE_USE_FQN").lower() == 'true'
+
+
+def get_custom_defined_service_name():
+    return os.environ.get("AUTODYNATRACE_CUSTOM_SERVICE_NAME")
+
+
 def generate_service_name(wrapped):
-    if os.environ.get("AUTODYNATRACE_CUSTOM_SERVICE_NAME"):
-        return os.environ.get("AUTODYNATRACE_CUSTOM_SERVICE_NAME")
+    if get_custom_defined_service_name():
+        return get_custom_defined_service_name()
+    else:
+        return get_module_path(wrapped)
 
-    service_name = wrapped.__module__
+
+def get_module_path(wrapped):
+    module_path = wrapped.__module__
+    class_name = None
+    qual_name = None
+    result = module_path
+
     if hasattr(wrapped, "im_class"):
-        service_name = wrapped.im_class.__name__
-    if hasattr(wrapped, "__qualname__") and "." in wrapped.__qualname__:
-        service_name = wrapped.__qualname__.split(".")[0]
+        class_name = wrapped.im_class.__name__
+        result = class_name
 
-    return service_name
+    if hasattr(wrapped, "__qualname__") and "." in wrapped.__qualname__:
+        qual_name = wrapped.__qualname__.split(".")[0]
+        result = qual_name
+
+    if use_fully_qualified_name():
+        result = ".".join([i for i in [module_path, class_name, qual_name] if i])
+
+    return result
+
+
+def generate_method_name(wrapped):
+    name = wrapped.__name__
+    if get_custom_defined_service_name() or use_fully_qualified_name():
+        path = get_module_path(wrapped)
+        return path + "." + name
+    else:
+        return name
 
 
 def dynatrace_custom_tracer(wrapped):
     @functools.wraps(wrapped)
     def wrapper(*args, **kwargs):
-        method_name = wrapped.__name__
+        method_name = generate_method_name(wrapped)
         service_name = generate_service_name(wrapped)
 
         with sdk.trace_custom_service(method_name, service_name):

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -25,6 +25,9 @@ class MyClass:
 
 def test_custom_service_name():
     my_class = MyClass()
+
+    os.environ.pop("AUTODYNATRACE_CUSTOM_SERVICE_USE_FQN", None)
+    os.environ.pop("AUTODYNATRACE_CUSTOM_SERVICE_NAME", None)
     assert custom_wrapper.generate_service_name(module_function) == "tests.test_custom"
     assert custom_wrapper.generate_service_name(my_class.class_method) == "MyClass"
     assert custom_wrapper.generate_service_name(module_function) == custom_wrapper.generate_service_name(another_function)
@@ -38,6 +41,76 @@ def test_custom_service_name():
 
     os.environ["AUTODYNATRACE_CUSTOM_SERVICE_NAME"] = "CustomServiceName"
     assert custom_wrapper.generate_service_name(module_function) == "CustomServiceName"
+
+
+def test_custom_service_name_fqn_true():
+    my_class = MyClass()
+
+    os.environ["AUTODYNATRACE_CUSTOM_SERVICE_USE_FQN"] = "TRUE"
+    os.environ.pop("AUTODYNATRACE_CUSTOM_SERVICE_NAME", None)
+    assert custom_wrapper.generate_service_name(module_function) == "tests.test_custom"
+    assert custom_wrapper.generate_service_name(my_class.class_method) == "tests.test_custom.MyClass"
+    assert custom_wrapper.generate_service_name(module_function) == custom_wrapper.generate_service_name(another_function)
+
+    if sys.version_info[0] == 2:
+        assert custom_wrapper.generate_service_name(my_class.static_method) == "tests.test_custom"
+        assert custom_wrapper.generate_service_name(MyClass.static_method) == "tests.test_custom"
+    else:
+        assert custom_wrapper.generate_service_name(my_class.static_method) == "tests.test_custom.MyClass"
+        assert custom_wrapper.generate_service_name(MyClass.static_method) == "tests.test_custom.MyClass"
+
+    os.environ["AUTODYNATRACE_CUSTOM_SERVICE_NAME"] = "CustomServiceName"
+    assert custom_wrapper.generate_service_name(module_function) == "CustomServiceName"
+
+
+def test_custom_method_name_fqn_false():
+    my_class = MyClass()
+
+    os.environ.pop("AUTODYNATRACE_CUSTOM_SERVICE_USE_FQN", None)
+    os.environ.pop("AUTODYNATRACE_CUSTOM_SERVICE_NAME", None)
+    assert custom_wrapper.generate_method_name(module_function) == "module_function"
+    assert custom_wrapper.generate_method_name(my_class.class_method) == "class_method"
+    assert custom_wrapper.generate_method_name(another_function) == "another_function"
+
+    assert custom_wrapper.generate_method_name(my_class.static_method) == "static_method"
+    assert custom_wrapper.generate_method_name(MyClass.static_method) == "static_method"
+
+    os.environ["AUTODYNATRACE_CUSTOM_SERVICE_NAME"] = "CustomServiceName"
+    assert custom_wrapper.generate_method_name(module_function) == "tests.test_custom.module_function"
+    assert custom_wrapper.generate_method_name(my_class.class_method) == "MyClass.class_method"
+    assert custom_wrapper.generate_method_name(another_function) == "tests.test_custom.another_function"
+
+    if sys.version_info[0] == 2:
+        assert custom_wrapper.generate_method_name(my_class.static_method) == "tests.test_custom.static_method"
+        assert custom_wrapper.generate_method_name(MyClass.static_method) == "tests.test_custom.static_method"
+    else:
+        assert custom_wrapper.generate_method_name(my_class.static_method) == "MyClass.static_method"
+        assert custom_wrapper.generate_method_name(MyClass.static_method) == "MyClass.static_method"
+
+
+def test_custom_method_name_fqn_true():
+    my_class = MyClass()
+
+    os.environ["AUTODYNATRACE_CUSTOM_SERVICE_USE_FQN"] = "TRUE"
+    os.environ.pop("AUTODYNATRACE_CUSTOM_SERVICE_NAME", None)
+    assert custom_wrapper.generate_method_name(module_function) == "tests.test_custom.module_function"
+    assert custom_wrapper.generate_method_name(my_class.class_method) == "tests.test_custom.MyClass.class_method"
+    assert custom_wrapper.generate_method_name(another_function) == "tests.test_custom.another_function"
+
+    assert custom_wrapper.generate_method_name(my_class.static_method) == "tests.test_custom.MyClass.static_method"
+    assert custom_wrapper.generate_method_name(MyClass.static_method) == "tests.test_custom.MyClass.static_method"
+
+    os.environ["AUTODYNATRACE_CUSTOM_SERVICE_NAME"] = "CustomServiceName"
+    assert custom_wrapper.generate_method_name(module_function) == "tests.test_custom.module_function"
+    assert custom_wrapper.generate_method_name(my_class.class_method) == "tests.test_custom.MyClass.class_method"
+    assert custom_wrapper.generate_method_name(another_function) == "tests.test_custom.another_function"
+
+    if sys.version_info[0] == 2:
+        assert custom_wrapper.generate_method_name(my_class.static_method) == "tests.test_custom.static_method"
+        assert custom_wrapper.generate_method_name(MyClass.static_method) == "tests.test_custom.static_method"
+    else:
+        assert custom_wrapper.generate_method_name(my_class.static_method) == "tests.test_custom.MyClass.static_method"
+        assert custom_wrapper.generate_method_name(MyClass.static_method) == "tests.test_custom.MyClass.static_method"
 
 
 def test_custom_service_instrumentation():


### PR DESCRIPTION
This PR introduces a AUTODYNATRACE_CUSTOM_SERVICE_USE_FQN environment variable that enables the use of fully qualified names for custom service names and methods.

For example, if the variable is set to "true", the naming will change to:
- Service: "MyClass" => "tests.test_custom.MyClass"
- Method: "class_method" => "tests.test_custom.MyClass.class_method"

This is also useful in case you use the "AUTODYNATRACE_CUSTOM_SERVICE_NAME" option. If not using fully qualified names all functions with the same name of different classes (e.g. "dump()") would be grouped together under that user-defined custom service name. This also relates to #34 .
- Service: "MyCustomName"
- Method: "tests.test_custom.MyClass.class_method"

Tests have been added to validate the combinations of the different configuration options.
