### PR TITLE
Add support for @classmethod decorator

### DIFF
--- a/autodynatrace/wrappers/custom/wrapper.py
+++ b/autodynatrace/wrappers/custom/wrapper.py
@@ -22,7 +22,12 @@ def generate_service_name(wrapped):
 
 
 def get_module_path(wrapped):
-    module_path = wrapped.__module__
+    module_path = "unknown"
+    if hasattr(wrapped, "__module__"):
+        module_path = wrapped.__module__
+    elif hasattr(wrapped, "__func__"):
+        return get_module_path(wrapped.__func__)
+
     class_name = None
     qual_name = None
     result = module_path
@@ -42,7 +47,12 @@ def get_module_path(wrapped):
 
 
 def generate_method_name(wrapped):
-    name = wrapped.__name__
+    name = "unknown"
+    if hasattr(wrapped, "__name__"):
+        name = wrapped.__name__
+    elif hasattr(wrapped, "__func__"):
+        return generate_method_name(wrapped.__func__)
+
     if get_custom_defined_service_name() or use_fully_qualified_name():
         path = get_module_path(wrapped)
         return "{}.{}".format(path, name)

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -30,6 +30,7 @@ def test_custom_service_name():
     os.environ.pop("AUTODYNATRACE_CUSTOM_SERVICE_NAME", None)
     assert custom_wrapper.generate_service_name(module_function) == "tests.test_custom"
     assert custom_wrapper.generate_service_name(my_class.class_method) == "MyClass"
+    assert custom_wrapper.generate_service_name(classmethod(my_class.class_method)) == "MyClass"
     assert custom_wrapper.generate_service_name(module_function) == custom_wrapper.generate_service_name(another_function)
 
     if sys.version_info[0] == 2:
@@ -50,6 +51,7 @@ def test_custom_service_name_fqn_true():
     os.environ.pop("AUTODYNATRACE_CUSTOM_SERVICE_NAME", None)
     assert custom_wrapper.generate_service_name(module_function) == "tests.test_custom"
     assert custom_wrapper.generate_service_name(my_class.class_method) == "tests.test_custom.MyClass"
+    assert custom_wrapper.generate_service_name(classmethod(my_class.class_method)) == "tests.test_custom.MyClass"
     assert custom_wrapper.generate_service_name(module_function) == custom_wrapper.generate_service_name(another_function)
 
     if sys.version_info[0] == 2:
@@ -70,6 +72,7 @@ def test_custom_method_name_fqn_false():
     os.environ.pop("AUTODYNATRACE_CUSTOM_SERVICE_NAME", None)
     assert custom_wrapper.generate_method_name(module_function) == "module_function"
     assert custom_wrapper.generate_method_name(my_class.class_method) == "class_method"
+    assert custom_wrapper.generate_method_name(classmethod(my_class.class_method)) == "class_method"
     assert custom_wrapper.generate_method_name(another_function) == "another_function"
 
     assert custom_wrapper.generate_method_name(my_class.static_method) == "static_method"
@@ -78,6 +81,7 @@ def test_custom_method_name_fqn_false():
     os.environ["AUTODYNATRACE_CUSTOM_SERVICE_NAME"] = "CustomServiceName"
     assert custom_wrapper.generate_method_name(module_function) == "tests.test_custom.module_function"
     assert custom_wrapper.generate_method_name(my_class.class_method) == "MyClass.class_method"
+    assert custom_wrapper.generate_method_name(classmethod(my_class.class_method)) == "MyClass.class_method"
     assert custom_wrapper.generate_method_name(another_function) == "tests.test_custom.another_function"
 
     if sys.version_info[0] == 2:
@@ -95,11 +99,13 @@ def test_custom_method_name_fqn_true():
     os.environ.pop("AUTODYNATRACE_CUSTOM_SERVICE_NAME", None)
     assert custom_wrapper.generate_method_name(module_function) == "tests.test_custom.module_function"
     assert custom_wrapper.generate_method_name(my_class.class_method) == "tests.test_custom.MyClass.class_method"
+    assert custom_wrapper.generate_method_name(classmethod(my_class.class_method)) == "tests.test_custom.MyClass.class_method"
     assert custom_wrapper.generate_method_name(another_function) == "tests.test_custom.another_function"
 
     os.environ["AUTODYNATRACE_CUSTOM_SERVICE_NAME"] = "CustomServiceName"
     assert custom_wrapper.generate_method_name(module_function) == "tests.test_custom.module_function"
     assert custom_wrapper.generate_method_name(my_class.class_method) == "tests.test_custom.MyClass.class_method"
+    assert custom_wrapper.generate_method_name(classmethod(my_class.class_method)) == "tests.test_custom.MyClass.class_method"
     assert custom_wrapper.generate_method_name(another_function) == "tests.test_custom.another_function"
 
     if sys.version_info[0] == 2:


### PR DESCRIPTION
Currently the following code:

```
class MyClass:

     @autodynatrace.trace
     @classmethod
    def class_method(self):
        pass
```

results in the following error:
```
 ../app_venv/lib/python3.8/site-packages/autodynatrace/wrappers/custom/wrapper.py:56: in wrapper
     method_name = generate_method_name(wrapped)
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 wrapped = <classmethod object at 0x7fa13a7da820>
     def generate_method_name(wrapped):
 >       name = wrapped.__name__
 E       AttributeError: 'classmethod' object has no attribute '__name__'
```

This PR fixes this issue by doing a safe check on the `__name__` and `__module__` properties and recursively checking the underlying `__func__`  object.

Tests have been added to cover this scenario.
