### PR TITLE
psycopg2 fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .vscode
 .pytest_cache
 __pycache__
+*.pyc
+.tox/
+autodynatrace.egg-info/

--- a/autodynatrace/wrappers/psycopg2/wrapper.py
+++ b/autodynatrace/wrappers/psycopg2/wrapper.py
@@ -46,8 +46,8 @@ def instrument():
             kwargs.setdefault("cursor_factory", self._dynatrace_cursor)
             return super(DynatraceConnection, self).cursor(*args, **kwargs)
 
-    psycopg2.extensions.connection = DynatraceConnection
 
     @wrapt.patch_function_wrapper("psycopg2", "connect")
     def dynatrace_connect(wrapped, instance, args, kwargs):
-        return DynatraceConnection(*args, **kwargs)
+        kwargs.setdefault('connection_factory', DynatraceConnection)
+        return wrapped(*args, **kwargs)


### PR DESCRIPTION
The current monkeypatch of psycopg2 breaks django database connections (see #43 )
The Psycopg2 connect factory function allows for a more subtle approach that is implemented here.