### PR TITLE
Add exception handling for Flask

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="autodynatrace",
-    version="1.0.75",
+    version="1.0.76",
     packages=find_packages(),
     package_data={"autodynatrace": ["wrappers/*"]},
     install_requires=["wrapt>=1.11.2", "oneagent-sdk>=1.3.0", "six>=1.10.0", "autowrapt>=1.0"],


### PR DESCRIPTION
This fixes cases where the exception is being captured by some other function/library and it can't be automatically traced by Dynatrace

It also fixes a double code invocation in the flask wrapper