### PR TITLE
Add FastAPI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ For most technologies, just import it in your code.
 - **confluent_kafka**
 - **cx_Oracle**
 - **django**
+- **fastapi**
 - **flask**
 - **grpc**
 - **paramiko**

--- a/autodynatrace/__init__.py
+++ b/autodynatrace/__init__.py
@@ -9,7 +9,7 @@ from wrapt.importer import when_imported
 from .log import init as log_init, logger
 from .sdk import init as sdk_init
 
-__version__ = 1.063
+__version__ = 1.077
 
 os.environ["DT_CUSTOM_PROP"] = "Autodynatrace={}".format(__version__)
 
@@ -45,6 +45,7 @@ INSTRUMENT_LIBS = [
     "paramiko",
     "psycopg2",
     "tornado",
+    "fastapi",
 ]
 
 

--- a/autodynatrace/wrappers/fastapi/__init__.py
+++ b/autodynatrace/wrappers/fastapi/__init__.py
@@ -1,0 +1,1 @@
+from .wrapper import instrument

--- a/autodynatrace/wrappers/fastapi/middleware.py
+++ b/autodynatrace/wrappers/fastapi/middleware.py
@@ -1,0 +1,58 @@
+import os
+
+from ...sdk import sdk
+from ...log import logger
+
+
+class DynatraceASGIMiddleware:
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+
+        # If this is not an http request, do nothing and return
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        request_headers = scope.get("headers", [])
+        headers = {}
+        for key, value in request_headers:
+            key = key.decode() if isinstance(key, bytes) else key
+            value = value.decode() if isinstance(value, bytes) else value
+            headers[key.lower()] = value
+
+        dt_tag = headers.get("x-dynatrace")
+
+        host = "{}:{}".format(scope["server"][0], scope["server"][1])
+        url = "{}://{}{}?{}".format(scope["scheme"], host, scope["path"], scope["query_string"].decode())
+        method = scope.get("method", "GET")
+        app = scope.get("app")
+        app_name = app.title if app is not None else "FastAPI"
+        root = scope.get("root_path", "/")
+
+        virtual_host = os.environ.get("AUTODYNATRACE_VIRTUAL_HOST", "{}".format(host))
+        app_name = os.environ.get("AUTODYNATRACE_APPLICATION_ID", "{}".format(app_name))
+        context_root = os.environ.get("AUTODYNATRACE_CONTEXT_ROOT", root or "/")
+
+        with sdk.create_web_application_info(virtual_host, app_name, context_root) as web_app_info:
+            with sdk.trace_incoming_web_request(web_app_info, url, method, headers=headers, str_tag=dt_tag) as tracer:
+                logger.debug(
+                    "dynatrace - asgi - AgentState: {}, Tracing url: '{}' with tag {}".format(sdk.agent_state, url, dt_tag)
+                )
+
+                async def wrapped_send(message):
+                    if message.get("type") == "http.response.start" and "status" in message:
+                        tracer.set_status_code(message["status"])
+
+                    if "headers" in message:
+                        response_headers = {}
+                        for k, v in message["headers"]:
+                            k = k.decode() if isinstance(k, bytes) else k
+                            v = v.decode() if isinstance(v, bytes) else v
+                            response_headers[k.lower()] = v
+
+                        tracer.add_response_headers(response_headers)
+
+                    return await send(message)
+
+                return await self.app(scope, receive, wrapped_send)

--- a/autodynatrace/wrappers/fastapi/wrapper.py
+++ b/autodynatrace/wrappers/fastapi/wrapper.py
@@ -1,0 +1,13 @@
+import fastapi
+from fastapi.middleware import Middleware
+from .middleware import DynatraceASGIMiddleware
+import wrapt
+
+
+def instrument():
+    @wrapt.patch_function_wrapper("fastapi.applications", "FastAPI.__init__")
+    def init_dynatrace(wrapped, instance, args, kwargs):
+        middlewares = kwargs.pop("middleware", [])
+        middlewares.insert(0, Middleware(DynatraceASGIMiddleware))
+        kwargs.update({"middleware": middlewares})
+        return wrapped(*args, **kwargs)

--- a/autodynatrace/wrappers/psycopg2/wrapper.py
+++ b/autodynatrace/wrappers/psycopg2/wrapper.py
@@ -46,8 +46,7 @@ def instrument():
             kwargs.setdefault("cursor_factory", self._dynatrace_cursor)
             return super(DynatraceConnection, self).cursor(*args, **kwargs)
 
-
     @wrapt.patch_function_wrapper("psycopg2", "connect")
     def dynatrace_connect(wrapped, instance, args, kwargs):
-        kwargs.setdefault('connection_factory', DynatraceConnection)
+        kwargs.setdefault("connection_factory", DynatraceConnection)
         return wrapped(*args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="autodynatrace",
-    version="1.0.76",
+    version="1.0.77",
     packages=find_packages(),
     package_data={"autodynatrace": ["wrappers/*"]},
     install_requires=["wrapt>=1.11.2", "oneagent-sdk>=1.3.0", "six>=1.10.0", "autowrapt>=1.0"],


### PR DESCRIPTION
Adds initial FastAPI support

Simply import autodynatrace on your main app file, or set the environment variable `AUTOWRAPT_BOOTSTRAP=autodynatrace` to use 

Fix #42