### PR TITLE
Fix confluent_kafka instrumentation.

### DIFF
--- a/autodynatrace/wrappers/confluent_kafka/wrapper.py
+++ b/autodynatrace/wrappers/confluent_kafka/wrapper.py
@@ -54,7 +54,7 @@ def instrument():
                 tag = tracer.outgoing_dynatrace_string_tag
                 logger.debug("kafka-producer Injecting message with header '{}'".format(tag))
                 headers = kwargs.get("headers", {})
-                headers.update({"x-dynatrace": tag})
+                headers.update({"dtdTraceTagInfo": tag})
                 kwargs["headers"] = headers
                 return wrapped(*args, **kwargs)
 
@@ -75,7 +75,7 @@ def instrument():
                     headers = message.headers()
                     if headers is not None:
                         for header in headers:
-                            if header[0].lower() == "x-dynatrace":
+                            if header[0].lower() == "dtdTraceTagInfo":
                                 tag = header[1]
                     with sdk.trace_incoming_message_process(msi_handle, str_tag=tag):
                         logger.debug("kafka-consumer: Received message with tag {}".format(tag))

--- a/autodynatrace/wrappers/confluent_kafka/wrapper.py
+++ b/autodynatrace/wrappers/confluent_kafka/wrapper.py
@@ -4,9 +4,12 @@ from ...log import logger
 from ...sdk import sdk
 from oneagent.common import MessagingDestinationType
 from oneagent.sdk import Channel, ChannelType
+from threading import Thread, local
 
 import confluent_kafka
 
+threadlocal = local()
+threadlocal.tracer = None
 
 class Producer(confluent_kafka.Producer):
     pass
@@ -60,6 +63,9 @@ def instrument():
 
     @wrapt.patch_function_wrapper("autodynatrace.wrappers.confluent_kafka.wrapper", "Consumer.poll")
     def custom_poll(wrapped, instance, args, kwargs):
+        if threadlocal.tracer is not None:
+           threadlocal.tracer.end()
+           threadlocal.tracer = None
         message = wrapped(*args, **kwargs)
         if message is not None:
             try:
@@ -77,9 +83,11 @@ def instrument():
                         for header in headers:
                             if header[0] == "dtdTraceTagInfo":
                                 tag = header[1]
-                    with sdk.trace_incoming_message_process(msi_handle, str_tag=tag):
-                        logger.debug("kafka-consumer: Received message with tag {}".format(tag))
-                        return message
+                    tracer = sdk.trace_incoming_message_process(msi_handle, str_tag=tag)
+                    tracer.start()
+                    threadlocal.tracer = tracer
+                    logger.debug("kafka-consumer: Received message with tag {}".format(tag))
+                    return message
             except Exception:
                 logger.debug("Could not trace Consumer.poll", exc_info=True)
                 return message

--- a/autodynatrace/wrappers/confluent_kafka/wrapper.py
+++ b/autodynatrace/wrappers/confluent_kafka/wrapper.py
@@ -75,7 +75,7 @@ def instrument():
                     headers = message.headers()
                     if headers is not None:
                         for header in headers:
-                            if header[0].lower() == "dtdTraceTagInfo":
+                            if header[0] == "dtdTraceTagInfo":
                                 tag = header[1]
                     with sdk.trace_incoming_message_process(msi_handle, str_tag=tag):
                         logger.debug("kafka-consumer: Received message with tag {}".format(tag))


### PR DESCRIPTION
This PR has 2 fixes.

1. Switched from using the x-dyantrace to dtdTraceTagInfo message header to transport the trace tag to be consistent with Dynatrace standards.
2. Changed the Consumer.poll() instrumentation so the trace is able to include more than just Consumer.poll() nodes.