### PR TITLE
feat(django-stomp): included helper to get queue type by destination name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 *.pyc
 .tox/
 autodynatrace.egg-info/
+.idea

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ For most technologies, just import it in your code.
 - **confluent_kafka**
 - **cx_Oracle**
 - **django**
+- **[django-stomp](https://pypi.org/project/django-stomp/)**
 - **fastapi**
 - **flask**
 - **grpc** (client)

--- a/autodynatrace/__init__.py
+++ b/autodynatrace/__init__.py
@@ -54,6 +54,7 @@ INSTRUMENT_LIBS = {
     "starlette": True,
     "aiohttp": True,
     "bottle": True,
+    "django_stomp": True,
 }
 
 

--- a/autodynatrace/wrappers/dbapi/__init__.py
+++ b/autodynatrace/wrappers/dbapi/__init__.py
@@ -8,7 +8,7 @@ from ..utils import normalize_vendor
 class TracedCursor(wrapt.ObjectProxy):
     def __init__(self, cursor, db_info):
         super(TracedCursor, self).__init__(cursor)
-        self.db_info = f"{db_info}"
+        self.db_info = db_info
         self._self_last_execute_operation = None
         self._original_cursor = cursor
 

--- a/autodynatrace/wrappers/django_stomp/__init__.py
+++ b/autodynatrace/wrappers/django_stomp/__init__.py
@@ -1,0 +1,1 @@
+from .wrapper import instrument

--- a/autodynatrace/wrappers/django_stomp/consumer.py
+++ b/autodynatrace/wrappers/django_stomp/consumer.py
@@ -1,0 +1,46 @@
+import oneagent
+from django.conf import settings
+from django.utils.module_loading import import_string
+from django_stomp import execution
+from ...log import logger
+from ...sdk import sdk
+from .utils import get_messaging_type_by_queue_name
+
+def instrument_consumer():
+    def wrapped_import_string(dotted_path):
+        callback_function = import_string(dotted_path)
+
+        def instrumented_callback(payload):
+            try:
+                headers = payload.headers
+                host, port = settings.STOMP_SERVER_HOST, settings.STOMP_SERVER_PORT
+                destination = headers.get("tshoot-destination")
+            except Exception as e:
+                logger.warn("autodynatrace - Could not trace Consumer(import_string): {}".format(e))
+                return callback_function(payload)
+
+            tag = None
+            if headers is not None:
+                tag = headers.get(oneagent.common.DYNATRACE_MESSAGE_PROPERTY_NAME, None)
+
+            messaging_system = sdk.create_messaging_system_info(
+                oneagent.common.MessagingVendor.RABBIT_MQ,
+                destination,
+                get_messaging_type_by_queue_name(destination),
+                oneagent.sdk.Channel(oneagent.sdk.ChannelType.TCP_IP, "{}:{}".format(host, port)),
+            )
+
+            with messaging_system:
+                with sdk.trace_incoming_message_receive(messaging_system):
+                    with sdk.trace_incoming_message_process(messaging_system, str_tag=tag) as process_message:
+                        process_message.set_correlation_id(headers.get("correlation-id"))
+                        process_message.set_vendor_message_id(headers.get("message-id"))
+                        logger.debug(
+                            f"autodynatrace - Tracing Incoming RabbitMQ host={host}, port={port},"
+                            f" routing_key={destination}, tag={tag}, headers={headers}"
+                        )
+                        return callback_function(payload)
+
+        return instrumented_callback
+
+    setattr(execution, "import_string", wrapped_import_string)

--- a/autodynatrace/wrappers/django_stomp/publisher.py
+++ b/autodynatrace/wrappers/django_stomp/publisher.py
@@ -1,0 +1,40 @@
+import oneagent
+import wrapt
+from django.conf import settings
+from django_stomp.services.producer import Publisher
+from ...log import logger
+from ...sdk import sdk
+from .utils import get_messaging_type_by_queue_name
+
+def instrument_publisher():
+    def on_send_message(wrapped, instance, args, kwargs):
+        try:
+            host, port = settings.STOMP_SERVER_HOST, settings.STOMP_SERVER_PORT
+            destination = kwargs.get("queue")
+            headers = kwargs.get("headers", {})
+
+        except Exception as e:
+            logger.warn("autodynatrace - Could not trace Publisher.send: {}".format(e))
+            return wrapped(*args, **kwargs)
+
+        messaging_system = sdk.create_messaging_system_info(
+            oneagent.common.MessagingVendor.RABBIT_MQ,
+            destination,
+            get_messaging_type_by_queue_name(destination),
+            oneagent.sdk.Channel(oneagent.sdk.ChannelType.TCP_IP, "{}:{}".format(host, port)),
+        )
+
+        tag = headers.get(oneagent.common.DYNATRACE_MESSAGE_PROPERTY_NAME, None)
+        with messaging_system:
+            with sdk.trace_outgoing_message(messaging_system) as outgoing_message:
+                outgoing_message.set_correlation_id(headers.get("correlation-id"))
+                if not tag:
+                    tag = outgoing_message.outgoing_dynatrace_string_tag.decode("utf-8")
+                    headers[oneagent.common.DYNATRACE_MESSAGE_PROPERTY_NAME] = tag
+                logger.debug(
+                    f"autodynatrace - Tracing Outgoing RabbitMQ host={host}, port={port}, routing_key={destination}, "
+                    f"tag={tag}, headers={headers}"
+                )
+                return wrapped(*args, **kwargs)
+
+    wrapt.wrap_function_wrapper(Publisher, "send", on_send_message)

--- a/autodynatrace/wrappers/django_stomp/utils.py
+++ b/autodynatrace/wrappers/django_stomp/utils.py
@@ -1,0 +1,14 @@
+from typing import Optional
+
+import oneagent
+
+
+def get_messaging_type_by_queue_name(queue_name: Optional[str] = None) -> int:
+    """Helper function to get queue type by name. If 'VirtualTopic' exists in the destination name
+    this queue is a TOPIC type.
+    By default the type of queue is QUEUE.
+    """
+    if queue_name and "VirtualTopic" in queue_name:
+        return oneagent.common.MessagingDestinationType.TOPIC
+
+    return oneagent.common.MessagingDestinationType.QUEUE

--- a/autodynatrace/wrappers/django_stomp/wrapper.py
+++ b/autodynatrace/wrappers/django_stomp/wrapper.py
@@ -1,0 +1,6 @@
+from .consumer import instrument_consumer
+from .publisher import instrument_publisher
+
+def instrument():
+    instrument_publisher()
+    instrument_consumer()

--- a/autodynatrace/wrappers/psycopg2/wrapper.py
+++ b/autodynatrace/wrappers/psycopg2/wrapper.py
@@ -11,7 +11,7 @@ def instrument():
     def parse_dsn(dsn):
         return {c.split("=")[0]: c.split("=")[1] for c in dsn.split() if "=" in c}
 
-    class DynatraceCursor(psycopg2.extra.DictCursorBase):
+    class DynatraceCursor(psycopg2.extensions.cursor):
         def __init__(self, *args, **kwargs):
             self._dynatrace_db_info = kwargs.pop("dynatrace_db_info", None)
             super(DynatraceCursor, self).__init__(*args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="autodynatrace",
-    version="2.0.0",
+    version="2.1.0",
     packages=find_packages(),
     package_data={"autodynatrace": ["wrappers/*"]},
     install_requires=["wrapt>=1.11.2", "oneagent-sdk>=1.3.0", "six>=1.10.0", "autowrapt>=1.0"],


### PR DESCRIPTION
It has included support for [django-stomp](https://pypi.org/project/django-stomp/5.2.0/) library. 
This library is for help publishing and consuming a message from a message broker (for example rabbitmq) using simple management commands.

[correlated working project](https://github.com/MatheusGeiger/django-with-instrumentation/tree/master/dynatrace-instrumentation/django_template/apps/dynatrace) with functional code.

<img width="1261" alt="Screenshot 2023-07-14 at 09 29 36" src="https://github.com/dynatrace-oss/OneAgent-SDK-Python-AutoInstrumentation/assets/22987079/807dc0ca-f634-4df2-a97a-481c75340c21">
