### PR TITLE
fix: ensure string url is used for dynatrace sdk trace

### DIFF
--- a/autodynatrace/wrappers/aiohttp/wrapper.py
+++ b/autodynatrace/wrappers/aiohttp/wrapper.py
@@ -11,7 +11,7 @@ def instrument():
     async def dynatrace_request(wrapped, instance, args, kwargs):
 
         method = args[0]
-        url = args[1]
+        url = str(args[1])
         headers = dict(kwargs.get("headers", {}))
 
         with sdk.trace_outgoing_web_request(url, method, headers) as tracer:


### PR DESCRIPTION
AIOHTTP can make a [client session request](https://docs.aiohttp.org/en/stable/client_quickstart.html#make-a-request) with a [str](https://docs.python.org/3/library/stdtypes.html#str) or class:yarl.URL instance.

The dynatrace `sdk.trace_outgoing_web_request` is [expecting a string](https://github.com/Dynatrace/OneAgent-SDK-for-Python/blob/8c7b1614dc3340d5c39038b1f231ac61efa09968/src/oneagent/sdk/__init__.py#L231C18-L231C18).

This fix just ensure that any class:yarl.URL objects are cast to a string before passing to the dynatrace sdk.

We've applied this fix to a service that was hitting this error condition and validated that it's working for us.


Original error stack trace:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/aiobotocore/httpsession.py", line 208, in send
   response = await self._session.request(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/autodynatrace/wrappers/aiohttp/wrapper.py", line 17, in dynatrace_request
   with sdk.trace_outgoing_web_request(url, method, headers) as tracer:
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/oneagent/sdk/__init__.py", line 260, in trace_outgoing_web_request


   self._nsdk, self._nsdk.outgoingwebrequesttracer_create(url, method))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ctypes.ArgumentError: argument 1: ValueError: Attempt to pass non-string type to SDK function expecting a string. Actual type: <class 'yarl.URL'>
```