### PR TITLE
Update wrapper.py | Fix to work with pymongo <4.4

### DIFF
--- a/autodynatrace/wrappers/pymongo/wrapper.py
+++ b/autodynatrace/wrappers/pymongo/wrapper.py
@@ -42,7 +42,7 @@ def instrument():
                     logger.debug("Got bad pymongo event: {}".format(event))
                     tracer.mark_failed("MongoDB Command", message)
 
-                logger.debug("Ending Mongo call: {}({})@{}:{}".format(event.command_name, event.database_name, event.connection_id[0], event.connection_id[1]))
+                logger.debug("Ending Mongo call: {}({})@{}:{}".format(event.command_name, getattr(event, 'database_name', "") , event.connection_id[0], event.connection_id[1]))
                 tracer.end()
                 self._tracer_dict.pop(_get_tracer_dict_key(event))
 


### PR DESCRIPTION
CommandSucceededEvent of pymongo 4.3 doesn't have the attribute database_name